### PR TITLE
Fix docker compose build failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ WORKDIR $INSTALL_PATH
 
 ADD *.gemspec $INSTALL_PATH
 ADD Gemfile* $INSTALL_PATH
+ADD lib/pacio_test_kit/version.rb $INSTALL_PATH/lib/pacio_test_kit/version.rb
+RUN gem update --system
 RUN gem install bundler
 # The below RUN line is commented out for development purposes, because any change to the
 # required gems will break the dockerfile build process.


### PR DESCRIPTION
This PR fix add missing version.rb in Dockerfile so that `docker compose build` could run successfully